### PR TITLE
METAMODEL-1169 Preserve milliseconds when rewriting query with Date operand

### DIFF
--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/SQLServerQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/SQLServerQueryRewriter.java
@@ -114,7 +114,7 @@ public class SQLServerQueryRewriter extends OffsetFetchQueryRewriter {
 
                 final Date date = (Date) operand;
 
-                final DateFormat format = DateUtils.createDateFormat("yyyyMMdd HH:mm:ss");
+                final DateFormat format = DateUtils.createDateFormat("yyyyMMdd HH:mm:ss.SSS");
                 final String dateTimeValue = "CAST('" + format.format(date) + "' AS DATETIME)";
 
                 sb.append(dateTimeValue);


### PR DESCRIPTION
Query rewriter for MS Sql database trimmed milliseconds for DATETIME or TIMESTAMP operands.